### PR TITLE
Fixes a11y issue with keyboard only users

### DIFF
--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1137,7 +1137,7 @@
 				// listen for key presses
 				t.globalBind('keydown', function(event) {
 					player.hasFocus = $(event.target).closest('.mejs-container').length !== 0;
-					return t.onkeydown(player, media, e);
+					return t.onkeydown(player, media, event);
 				});
 
 

--- a/src/js/mep-player.js
+++ b/src/js/mep-player.js
@@ -1135,7 +1135,8 @@
 				});
 
 				// listen for key presses
-				t.globalBind('keydown', function(e) {
+				t.globalBind('keydown', function(event) {
+					player.hasFocus = $(event.target).closest('.mejs-container').length !== 0;
 					return t.onkeydown(player, media, e);
 				});
 
@@ -1279,7 +1280,7 @@
 				//console.log("resetSize");
 				t.setPlayerSize(t.width, t.height);
 				t.setControlsSize();
-			}, 50);            
+			}, 50);
 		}
 	};
 


### PR DESCRIPTION
- Player would incorrectly assume it had focus
  when in fact it did not.
- Keyboard only users can focus elements using
  the tab key, thus listening to 'click' event
  alone would not work for them.
- This meant that it would be impossible to type
  in an input field on the same page without
  having keyboard events erroneously fired on
  the player.
